### PR TITLE
ステータス遷移チェック完了

### DIFF
--- a/app/views/admin/a_orders/index.html.erb
+++ b/app/views/admin/a_orders/index.html.erb
@@ -16,7 +16,7 @@
   <tbody>
     <% @a_orders.each do |a_order| %>  
       <tr>
-        <td><%= link_to a_order.created_at, admin_a_order_path(a_order.id) %></td>
+        <td><%= link_to a_order.created_at.strftime('%Y/%m/%d'), admin_a_order_path(a_order.id) %></td>
         <td><%= a_order.customer.first_name %> <%= a_order.customer.last_name %></td>
         <td><%= a_order.order_items.all.sum(:quantity) %></td>
         <td>

--- a/app/views/admin/a_orders/show.html.erb
+++ b/app/views/admin/a_orders/show.html.erb
@@ -94,7 +94,7 @@
 <table>
   <tr>
     <th>商品合計</th>
-    <td><%= @item.all.sum(:price * quantity) %></td>
+    <td><%= @order.total_price %></td>
   </tr>
   <tr>
     <th>送料</th>

--- a/app/views/customer/c_orders/index.html.erb
+++ b/app/views/customer/c_orders/index.html.erb
@@ -26,7 +26,21 @@
           <% end %>
         </td>
         <td><%= order.total_price + order.postage %></td>
-        <td><%= order.order_status %></td>
+        <td>
+          <% if order.order_status == 0 %>
+            入金待ち
+          <% elsif order.order_status == 1 %>
+            <% if (!order.order_items.where(create_status:1).exists?) && (!order.order_items.where(create_status:2).exists?) %>
+              入金確認
+            <% elsif (!order.order_items.where(create_status:0).exists?) && (!order.order_items.where(create_status:1).exists?) %>
+              発送準備中
+            <% else %>
+              製作中
+            <% end %>
+          <% else %>
+            発送済み
+          <% end %>  
+        </td>
         <td><%= link_to "表示する", c_order_path(order) %></td>
       </tr>
     <% end %>

--- a/app/views/customer/c_orders/show.html.erb
+++ b/app/views/customer/c_orders/show.html.erb
@@ -21,7 +21,21 @@
     </tr>
       <tr>
       <th>ステータス</th>
-      <td><%= @order.order_status %></td>
+      <td>
+        <% if @order.order_status == 0 %>
+          入金待ち
+        <% elsif @order.order_status == 1 %>
+          <% if (!@order.order_items.where(create_status:1).exists?) && (!@order.order_items.where(create_status:2).exists?) %>
+            入金確認
+          <% elsif (!@order.order_items.where(create_status:0).exists?) && (!@order.order_items.where(create_status:1).exists?) %>
+            発送準備中
+          <% else %>
+            製作中
+          <% end %>
+        <% else %>
+          発送済み
+        <% end %>    
+      </td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
・管理者側の注文一覧注文→注文詳細画面のエラー解決。
・顧客側の注文履歴一覧、注文履歴詳細それぞれの「ステータス」が一通り正常に表示されることを確認。
